### PR TITLE
Fix nested field $gt filter behaviour

### DIFF
--- a/packages/node_modules/pouchdb-find/src/adapters/local/utils.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/utils.js
@@ -44,10 +44,16 @@ function massageIndexDef(indexDef) {
 }
 
 function getKeyFromDoc(doc, index) {
-  var res = [];
-  for (var i = 0; i < index.def.fields.length; i++) {
-    var field = getKey(index.def.fields[i]);
-    res.push(doc[field]);
+  const res = [];
+  for (let i = 0; i < index.def.fields.length; i++) {
+    const field = getKey(index.def.fields[i]);
+    let propertyParent = doc;
+    const keys = field.split('.');
+    const propertyName = keys.pop();
+    while (keys.length > 0) {
+      propertyParent = propertyParent[keys.shift()];
+    }
+    res.push(propertyParent[propertyName]);
   }
   return res;
 }


### PR DESCRIPTION
BUG: Querying with $gt over a nested field returns the wrong results https://github.com/pouchdb/pouchdb/pull/8471

The nested field did result undefined docs, so no filtering worked at all, when filterInclusiveStart called. (asc and gt in the same time)